### PR TITLE
Add Uno R4 connectivity and sketch

### DIFF
--- a/allSensors/allSensors/allSensors.ino
+++ b/allSensors/allSensors/allSensors.ino
@@ -28,6 +28,9 @@ static inline void tcaSelect(uint8_t ch) {
 }
 #define OLED_SELECT() tcaSelect(SCREEN_CHANNEL)
 #define RTC_SELECT()  tcaSelect(SCREEN_CHANNEL)  // RTC shares CH7
+#define UNO_R4_CHANNEL 4      // TCA9548A channel for external Uno R4
+#define UNO_R4_ADDR    0x08   // I2C address of the Uno R4
+#define UNO_R4_SELECT() tcaSelect(UNO_R4_CHANNEL)
 // -------------------- OLED instance --------------------
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 RTC_DS3231 rtc;
@@ -144,6 +147,12 @@ void resetChannelGroup(uint8_t ch) {
     pinMode(xshutPins[gi], OUTPUT);
     digitalWrite(xshutPins[gi], LOW);
   }
+}
+
+bool connectUnoR4() {
+  UNO_R4_SELECT();
+  Wire.beginTransmission(UNO_R4_ADDR);
+  return (Wire.endTransmission() == 0);
 }
 
 // --- SHUTDOWN SEQUENCE ---
@@ -264,6 +273,16 @@ void setup() {
   // RTC
   RTC_SELECT();
   rtc.begin(); // assume time is already set
+
+  // Uno R4 on channel 4
+  bool unoR4Ok = connectUnoR4();
+  tcaSelect(SCREEN_CHANNEL);
+  display.clearDisplay();
+  display.setCursor(0,0);
+  display.print(F("UNO R4: "));
+  display.println(unoR4Ok ? F("OK") : F("FAIL"));
+  display.display();
+  delay(400);
   
   // Initial switch state
   prevSwOn = readSwitchOn();

--- a/unoR4/unoR4.ino
+++ b/unoR4/unoR4.ino
@@ -1,0 +1,41 @@
+#include <WiFiS3.h>
+#include <Wire.h>
+
+const char ssid[] = "YOUR_SSID";      // replace with your network SSID
+const char pass[] = "YOUR_PASSWORD";   // replace with your network password
+
+const int I2C_ADDRESS = 0x08;
+
+void onReceive(int numBytes) {
+  while (Wire.available()) {
+    char c = Wire.read();
+    // handle received data
+  }
+}
+
+void onRequest() {
+  const char response[] = "OK";
+  Wire.write((const uint8_t*)response, sizeof(response)-1);
+}
+
+void setup() {
+  Serial.begin(115200);
+  Wire.begin(I2C_ADDRESS);       // join I2C bus with specified address
+  Wire.onReceive(onReceive);     // register event handlers
+  Wire.onRequest(onRequest);
+
+  int status = WL_IDLE_STATUS;
+  while (status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(ssid);
+    status = WiFi.begin(ssid, pass);
+    delay(10000);
+  }
+  Serial.println("Connected to WiFi");
+}
+
+void loop() {
+  // main loop can be extended as needed
+  delay(1000);
+}
+


### PR DESCRIPTION
## Summary
- connect Uno R4 via TCA9548A channel 4 in main sketch and display connection status
- include helper function and macros for selecting Uno R4 multiplexer channel
- add Uno R4 sketch with WiFiS3 and Wire libraries for Wi-Fi and I2C communication

## Testing
- `arduino-cli compile --fqbn arduino:renesas_uno allSensors/allSensors/allSensors.ino` *(fails: command not found)*
- `arduino-cli compile --fqbn arduino:renesas_uno unoR4/unoR4.ino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d430a36c833181e1e61fa67b2f93