### PR TITLE
Add Uno R4 MQTT publisher with LED status

### DIFF
--- a/allSensors/allSensors/allSensors.ino
+++ b/allSensors/allSensors/allSensors.ino
@@ -28,6 +28,9 @@ static inline void tcaSelect(uint8_t ch) {
 }
 #define OLED_SELECT() tcaSelect(SCREEN_CHANNEL)
 #define RTC_SELECT()  tcaSelect(SCREEN_CHANNEL)  // RTC shares CH7
+#define UNO_R4_CHANNEL 4      // TCA9548A channel for external Uno R4
+#define UNO_R4_ADDR    0x08   // I2C address of the Uno R4
+#define UNO_R4_SELECT() tcaSelect(UNO_R4_CHANNEL)
 // -------------------- OLED instance --------------------
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 RTC_DS3231 rtc;
@@ -144,6 +147,12 @@ void resetChannelGroup(uint8_t ch) {
     pinMode(xshutPins[gi], OUTPUT);
     digitalWrite(xshutPins[gi], LOW);
   }
+}
+
+bool connectUnoR4() {
+  UNO_R4_SELECT();
+  Wire.beginTransmission(UNO_R4_ADDR);
+  return (Wire.endTransmission() == 0);
 }
 
 // --- SHUTDOWN SEQUENCE ---
@@ -264,6 +273,16 @@ void setup() {
   // RTC
   RTC_SELECT();
   rtc.begin(); // assume time is already set
+
+  // Uno R4 on channel 4
+  bool unoR4Ok = connectUnoR4();
+  tcaSelect(SCREEN_CHANNEL);
+  display.clearDisplay();
+  display.setCursor(0,0);
+  display.print(F("UNO R4: "));
+  display.println(unoR4Ok ? F("OK") : F("FAIL"));
+  display.display();
+  delay(400);
   
   // Initial switch state
   prevSwOn = readSwitchOn();

--- a/mqtt_listener.py
+++ b/mqtt_listener.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Simple MQTT subscriber for testing Uno R4 publishes.
+
+Connects to a local broker and prints any messages published on the
+`unoR4/random` topic.
+"""
+
+import paho.mqtt.client as mqtt
+
+BROKER = "localhost"  # replace with broker IP if not local
+TOPIC = "unoR4/random"
+
+
+def on_connect(client, userdata, flags, rc):
+    """Subscribe to the topic once connected."""
+    print(f"Connected with result code {rc}")
+    client.subscribe(TOPIC)
+
+
+def on_message(client, userdata, msg):
+    """Print incoming MQTT messages."""
+    print(f"{msg.topic}: {msg.payload.decode()}")
+
+
+client = mqtt.Client()
+client.on_connect = on_connect
+client.on_message = on_message
+
+client.connect(BROKER, 1883, 60)
+client.loop_forever()
+

--- a/unoR4/unoR4.ino
+++ b/unoR4/unoR4.ino
@@ -1,0 +1,71 @@
+#include <WiFiS3.h>
+#include <Wire.h>
+#include <Arduino_LED_Matrix.h>
+#include <ArduinoMqttClient.h>
+
+const char ssid[] = "YOUR_SSID";      // replace with your network SSID
+const char pass[] = "YOUR_PASSWORD";   // replace with your network password
+
+const char broker[] = "BROKER_IP";    // replace with MQTT broker IP or host
+const int  brokerPort = 1883;
+const char topic[] = "unoR4/random";
+
+const int I2C_ADDRESS = 0x08;
+
+ArduinoLEDMatrix matrix;
+WiFiClient wifiClient;
+MqttClient mqttClient(wifiClient);
+
+void onReceive(int numBytes) {
+  while (Wire.available()) {
+    char c = Wire.read();
+    // handle received data
+  }
+}
+
+void onRequest() {
+  const char response[] = "OK";
+  Wire.write((const uint8_t*)response, sizeof(response)-1);
+}
+
+void showStatus(const char *msg) {
+  matrix.clear();
+  matrix.print(msg);
+}
+
+void setup() {
+  Serial.begin(115200);
+  Wire.begin(I2C_ADDRESS);       // join I2C bus with specified address
+  Wire.onReceive(onReceive);     // register event handlers
+  Wire.onRequest(onRequest);
+
+  matrix.begin();
+  showStatus("W");
+
+  int status = WL_IDLE_STATUS;
+  while (status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(ssid);
+    status = WiFi.begin(ssid, pass);
+    delay(10000);
+  }
+  Serial.println("Connected to WiFi");
+
+  showStatus("M");
+  if (!mqttClient.connect(broker, brokerPort)) {
+    Serial.println("MQTT connection failed");
+    showStatus("E");
+  } else {
+    Serial.println("MQTT connected");
+    showStatus("C");
+  }
+}
+
+void loop() {
+  mqttClient.poll();
+  mqttClient.beginMessage(topic);
+  mqttClient.print(random(0, 100));
+  mqttClient.endMessage();
+  delay(1000);
+}
+


### PR DESCRIPTION
## Summary
- use Uno R4 LED matrix to show Wi-Fi/MQTT connection state
- publish random numbers to a configurable MQTT broker
- add Python helper to subscribe to Uno R4 MQTT topic

## Testing
- `arduino-cli compile --fqbn arduino:renesas_uno unoR4/unoR4.ino` *(fails: command not found)*
- `python3 -m py_compile mqtt_listener.py`
- `python3 mqtt_listener.py` *(fails: No module named 'paho')*
- `pip install paho-mqtt` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d430a36c833181e1e61fa67b2f93