### PR TITLE
Refactor Arduino loops to use interrupts

### DIFF
--- a/allSensors/allSensors/allSensors.ino
+++ b/allSensors/allSensors/allSensors.ino
@@ -3,6 +3,8 @@
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include <RTClib.h>
+#include <TimerOne.h>
+#include <PinChangeInterrupt.h>
 
 // --- Power / control pins ---
 #define POWER_HOLD_PIN     26   // output, goes HIGH after boot
@@ -17,7 +19,7 @@
 #define SCREEN_HEIGHT   64
 #define OLED_RESET      -1
 #define SCREEN_ADDRESS  0x3D
-#define SCREEN_CHANNEL  7      // TCA9548A channel for OLED (and RTC if present)
+#define SCREEN_CHANNEL  7      // TCA9548A channel for OLED and RTC
 // -------------------- TCA9548A --------------------
 #define TCA_ADDRESS     0x70
 static inline void tcaSelect(uint8_t ch) {
@@ -27,7 +29,7 @@ static inline void tcaSelect(uint8_t ch) {
   Wire.endTransmission();
 }
 #define OLED_SELECT() tcaSelect(SCREEN_CHANNEL)
-#define RTC_SELECT()  tcaSelect(SCREEN_CHANNEL)  // RTC shares CH7
+#define RTC_SELECT()  tcaSelect(SCREEN_CHANNEL)
 #define UNO_R4_CHANNEL 4      // TCA9548A channel for external Uno R4
 #define UNO_R4_ADDR    0x08   // I2C address of the Uno R4
 #define UNO_R4_SELECT() tcaSelect(UNO_R4_CHANNEL)
@@ -53,6 +55,12 @@ const uint8_t xshutPins[SENSOR_COUNT] = {
 const uint8_t perChannelAddr[SENSORS_PER_CHANNEL] = { 0x30, 0x31, 0x32 };
 
 VL53L1X sensors[SENSOR_COUNT];
+
+volatile bool updateFlag = false;
+volatile bool shutdownFlag = false;
+
+void timerISR() { updateFlag = true; }
+void switchISR() { if (digitalRead(SWITCH_DETECT_PIN) == HIGH) shutdownFlag = true; }
 
 // -------------------- STEP/DIR DRIVER --------------------
 // New driver: STEP on pin 33, DIR on pin 31
@@ -256,6 +264,56 @@ bool sendDistancesFramed(const uint16_t *vals) {
 }
 
 
+void readAndSend() {
+  // Keep RTC time updated even if not displayed
+  RTC_SELECT();
+  rtc.now();
+
+  uint16_t distances[SENSOR_COUNT];
+  uint8_t statuses[SENSOR_COUNT];
+  for (uint8_t ch = 0; ch < SENSOR_CHANNELS; ch++) {
+    tcaSelect(ch);
+    for (uint8_t i = 0; i < SENSORS_PER_CHANNEL; i++) {
+      uint8_t idx = ch * SENSORS_PER_CHANNEL + i;
+      sensors[idx].read();
+      distances[idx] = sensors[idx].ranging_data.range_mm;
+      statuses[idx]  = sensors[idx].ranging_data.range_status;
+    }
+  }
+
+  sendDistancesFramed(distances);
+
+  OLED_SELECT();
+  display.clearDisplay();
+  display.setTextSize(1);
+  for (uint8_t i = 0; i < SENSOR_COUNT; i += 2) {
+    uint8_t y = (i / 2) * 10;
+    display.setCursor(0, y);
+    display.print(F("S")); display.print(i + 1); display.print(F(":"));
+    if (statuses[i] == 0) display.print(distances[i]);
+    else display.print(F("--"));
+    display.setCursor(64, y);
+    display.print(F("S")); display.print(i + 2); display.print(F(":"));
+    if (statuses[i + 1] == 0) display.print(distances[i + 1]);
+    else display.print(F("--"));
+  }
+  display.display();
+
+  bool s1Valid = (statuses[0] == 0);
+  if (s1Valid && distances[0] < TRIGGER_MM) {
+    if (s1HitCount < 255) s1HitCount++;
+  } else {
+    s1HitCount = 0;
+  }
+
+  bool doMove = (s1HitCount >= REQ_CONSEC) && (millis() - lastMoveMs > moveCooldownMs);
+  if (doMove) {
+    motorStep(STEPS_90, true);
+    lastMoveMs = millis();
+    s1HitCount = 0;
+  }
+}
+
 // --- SHUTDOWN SEQUENCE ---
 void drawSleepingBird(int x,int y){
   OLED_SELECT();
@@ -301,9 +359,6 @@ const uint16_t TRIGGER_MM = 150;
 const uint8_t  REQ_CONSEC  = 3;
 uint8_t s1HitCount = 0;
 
-bool readSwitchOn() { return (digitalRead(SWITCH_DETECT_PIN) == LOW); } // LOW = ON
-bool prevSwOn = true;
-unsigned long swChangeMs = 0;
 
 
 
@@ -321,6 +376,11 @@ void setup() {
   // Bring up rails BEFORE touching OLED
   pinMode(CHARGER_DETECT_PIN, INPUT);       // expects 0/5V from divider
   pinMode(SWITCH_DETECT_PIN,  INPUT_PULLUP);// LOW when switch ON (change to INPUT if externally driven)
+
+  attachPCINT(digitalPinToPCINT(SWITCH_DETECT_PIN), switchISR, CHANGE);
+
+  Timer1.initialize(100000); // 100ms intervals
+  Timer1.attachInterrupt(timerISR);
 
   // STEP/DIR outputs
   pinMode(STEP_PIN, OUTPUT);
@@ -350,6 +410,10 @@ void setup() {
   display.display();
   delay(1000);
 
+  // RTC
+  RTC_SELECT();
+  rtc.begin(); // assume time is already set
+
   // Put all sensors on all channels into reset first
   for (uint8_t ch = 0; ch < SENSOR_CHANNELS; ch++) {
     resetChannelGroup(ch);
@@ -373,23 +437,21 @@ void setup() {
   }
   
 
-  // RTC
-  RTC_SELECT();
-  rtc.begin(); // assume time is already set
-
-  // Uno R4 on channel 4
-  bool unoR4Ok = connectUnoR4();
+  // Uno R4 on channel 4 with 10s timeout
+  bool unoR4Ok = false;
+  unsigned long startAttempt = millis();
+  while (millis() - startAttempt < 10000 && !unoR4Ok) {
+    unoR4Ok = connectUnoR4();
+    if (!unoR4Ok) delay(500);
+  }
   tcaSelect(SCREEN_CHANNEL);
   display.clearDisplay();
   display.setCursor(0,0);
   display.print(F("UNO R4: "));
   display.println(unoR4Ok ? F("OK") : F("FAIL"));
   display.display();
-  delay(3000);
+  delay(1000);
   
-  // Initial switch state
-  prevSwOn = readSwitchOn();
-
   // Ready banner
   tcaSelect(SCREEN_CHANNEL);
   display.clearDisplay();
@@ -402,115 +464,13 @@ void setup() {
 
 
 void loop() {
-  // ---- Switch OFF detection with simple debounce ----
-  bool swOn = readSwitchOn();
-  if (swOn != prevSwOn){
-    swChangeMs = millis();
-    prevSwOn = swOn;
+  if (shutdownFlag) {
+    shutdownFlag = false;
+    shutdownSequence();
   }
-  // If it has been off (HIGH) for >80ms, begin shutdown
-  if (!swOn && (millis() - swChangeMs > 80)){
-    shutdownSequence();  // does not return
+  if (updateFlag) {
+    updateFlag = false;
+    readAndSend();
   }
-  // ---- time on first line ----
-  RTC_SELECT();
-  DateTime now = rtc.now();
-  char timebuf[9];
-  snprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d", now.hour(), now.minute(), now.second());
-
-  OLED_SELECT();
-  display.clearDisplay();
-  display.setTextSize(1);
-  display.setCursor(0,0);
-  display.print(timebuf);
-
-  // --- Read S1..S3 on channel 0 only ---
-  // tcaSelect(0);
-  // sensors[0].read(); uint16_t d1 = sensors[0].ranging_data.range_mm; uint8_t st1 = sensors[0].ranging_data.range_status;
-  // sensors[1].read(); uint16_t d2 = sensors[1].ranging_data.range_mm; uint8_t st2 = sensors[1].ranging_data.range_status;
-  // sensors[2].read(); uint16_t d3 = sensors[2].ranging_data.range_mm; uint8_t st3 = sensors[2].ranging_data.range_status;
-  // --- Read all sensors ---
-  uint16_t distances[SENSOR_COUNT];
-  uint8_t statuses[SENSOR_COUNT];
-  for (uint8_t ch = 0; ch < SENSOR_CHANNELS; ch++) {
-    tcaSelect(ch);
-    for (uint8_t i = 0; i < SENSORS_PER_CHANNEL; i++) {
-      uint8_t idx = ch * SENSORS_PER_CHANNEL + i;
-      sensors[idx].read();
-      distances[idx] = sensors[idx].ranging_data.range_mm;
-      statuses[idx]  = sensors[idx].ranging_data.range_status;
-    }
-  }
-
-  // --- Send data to Uno R4 ---
-  if (!sendDistancesFramed(distances)) {
-    // OLED_SELECT();
-    // display.clearDisplay();
-    // display.setTextSize(1);
-    // display.setCursor(12, 10);
-    // display.println(F("No"));
-    // display.setCursor(12, 32);
-    // display.println(F("send:("));
-    // display.display();
-    // delay(100); // show it briefly
-  }
-
-  // ---- display S1..S3 ----
-  OLED_SELECT();
-  auto showLine = [&](uint8_t y, uint8_t sNum, uint16_t d, uint8_t st){
-    display.setCursor(0,y);
-    display.print(F("S")); display.print(sNum); display.print(F(": "));
-    if(st==0) { display.print(d); display.print(F(" mm")); }
-    else      { display.print(F("--")); }
-  };
-  // showLine(12,1,d1,st1);
-  // showLine(24,2,d2,st2);
-  // showLine(36,3,d3,st3);
-  showLine(12,1,distances[0],statuses[0]);
-  showLine(24,2,distances[1],statuses[1]);
-  showLine(36,3,distances[2],statuses[2]);
-
-  // --- Read control signals ---
-  bool powerHold = digitalRead(POWER_HOLD_PIN);      // output, but we can read back level
-  bool gate5v    = digitalRead(GATE_5V_PIN);
-  bool charger   = digitalRead(CHARGER_DETECT_PIN);  // HIGH = charger present
-  bool swOnEcho  = (digitalRead(SWITCH_DETECT_PIN) == LOW);
-
-  // --- Show control states (two lines at bottom) ---
-  
-  display.setCursor(0, 48);
-  display.print(F("PWR:")); display.print(powerHold ? F("ON ") : F("OFF"));
-  display.print(F(" 5V:")); display.print(gate5v ? F("ON") : F("OFF"));
-
-  display.setCursor(0, 58);
-  display.print(F("SW:"));  display.print(swOn ? F("ON ") : F("OFF "));
-  display.print(F(" CHG:")); display.print(charger ? F("YES") : F("NO"));
-
-  display.display();
-
-  // bool s1Valid = (st1 == 0);
-  // if(s1Valid && d1 < TRIGGER_MM) {
-  //   if(s1HitCount < 255) s1HitCount++;
-  bool s1Valid = (statuses[0] == 0);
-  if (s1Valid && distances[0] < TRIGGER_MM) {
-    if (s1HitCount < 255) s1HitCount++;
-  } else {
-    s1HitCount = 0;
-  }
-
-  bool doMove = (s1HitCount >= REQ_CONSEC) && (millis() - lastMoveMs > moveCooldownMs);
-  if(doMove){
-    display.setCursor(80, 48);
-    display.print(F("MOVE +90"));
-    display.display();
-
-    motorStep(STEPS_90, true);
-    lastMoveMs = millis();
-    s1HitCount = 0;           // reset after acting
-  }
-
-  tcaSelect(SCREEN_CHANNEL);
-  display.display();
-  delay(40);
 }
 

--- a/unoR4/unoR4.ino
+++ b/unoR4/unoR4.ino
@@ -10,7 +10,6 @@ const char pass[] = "leoponce82";   // replace with your network password
 const char broker[] = "10.60.245.204";    // replace with MQTT broker IP or host
 const int  brokerPort = 1883;
 const char topic[] = "birdBox/unoR4/sensors";
-const char random_topic[] = "birdBox/unoR4/random";
 
 const int I2C_ADDRESS = 0x08;
 #define HANDSHAKE_SIZE 1
@@ -18,7 +17,6 @@ String answer = "K";
 #define SENSOR_COUNT    12
 #define PAYLOAD_BYTES   (SENSOR_COUNT * 2)  // 24
 volatile uint16_t rcvDistances[SENSOR_COUNT];
-volatile bool newSensorData = false;
 volatile uint8_t st = 0;          // 0: wait 'D', 1: off, 2: cnt, 3: data
 volatile uint8_t f_off = 0;
 volatile uint8_t f_cnt = 0;
@@ -36,7 +34,10 @@ ArduinoLEDMatrix matrix;
 WiFiClient wifiClient;
 MqttClient mqttClient(wifiClient);
 
-uint16_t sensorValues[12];
+// publish interval in milliseconds
+const unsigned long PUBLISH_INTERVAL_MS = 100;
+unsigned long lastPublish = 0;
+volatile bool haveData = false;
 
 
 void onReceive(int) {
@@ -68,7 +69,7 @@ void onReceive(int) {
           gotMask |= (1u << (f_off + i));
         }
         // all 12 received at least once?
-        if (gotMask == 0x0FFF) { newSensorData = true; gotMask = 0; }
+        if (gotMask == 0x0FFF) { haveData = true; gotMask = 0; }
 
         st = 0; // ready for next frame
       }
@@ -175,17 +176,12 @@ void setup() {
 
 void loop() {
   mqttClient.poll();
-  // mqttClient.beginMessage(topic);
-  // mqttClient.print(random(0, 100));
-  // mqttClient.endMessage();
-  // delay(1000);
-  if (newSensorData) {
+  if (haveData && millis() - lastPublish >= PUBLISH_INTERVAL_MS) {
+    lastPublish = millis();
     noInterrupts();
     uint16_t snap[SENSOR_COUNT];
     for (int i = 0; i < SENSOR_COUNT; i++) snap[i] = rcvDistances[i];
-    newSensorData = false;
     interrupts();
-
     mqttClient.beginMessage(topic);
     for (int i = 0; i < SENSOR_COUNT; i++) {
       if (i) mqttClient.print(',');
@@ -193,11 +189,5 @@ void loop() {
     }
     mqttClient.endMessage();
   }
-  delay(100);
-  mqttClient.poll(); 
-  mqttClient.beginMessage(random_topic); 
-  mqttClient.print(random(0, 100)); 
-  mqttClient.endMessage(); 
-  delay(1000);
 }
 


### PR DESCRIPTION
## Summary
- Streamline Mega sensor sketch by removing clock/rail display, adding interrupt-driven updates, and adding a 10s timeout for Uno R4 handshake.
- Publish sensor readings from Uno R4 at a fixed rate using a simple `millis()` scheduler instead of the incompatible Ticker library.
- Retain RTC support without displaying the current time.

## Testing
- `arduino-cli --version` *(fails: command not found)*
- `python -m py_compile mqtt_listener.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc86249b4c83319709c76f96d5125d