### PR TITLE
Refactor Arduino loops to use interrupts

### DIFF
--- a/unoR4/unoR4.ino
+++ b/unoR4/unoR4.ino
@@ -10,7 +10,6 @@ const char pass[] = "leoponce82";   // replace with your network password
 const char broker[] = "10.60.245.204";    // replace with MQTT broker IP or host
 const int  brokerPort = 1883;
 const char topic[] = "birdBox/unoR4/sensors";
-const char random_topic[] = "birdBox/unoR4/random";
 
 const int I2C_ADDRESS = 0x08;
 #define HANDSHAKE_SIZE 1
@@ -18,7 +17,6 @@ String answer = "K";
 #define SENSOR_COUNT    12
 #define PAYLOAD_BYTES   (SENSOR_COUNT * 2)  // 24
 volatile uint16_t rcvDistances[SENSOR_COUNT];
-volatile bool newSensorData = false;
 volatile uint8_t st = 0;          // 0: wait 'D', 1: off, 2: cnt, 3: data
 volatile uint8_t f_off = 0;
 volatile uint8_t f_cnt = 0;
@@ -36,7 +34,10 @@ ArduinoLEDMatrix matrix;
 WiFiClient wifiClient;
 MqttClient mqttClient(wifiClient);
 
-uint16_t sensorValues[12];
+// publish interval in milliseconds
+const unsigned long PUBLISH_INTERVAL_MS = 100;
+unsigned long lastPublish = 0;
+volatile bool haveData = false;
 
 
 void onReceive(int) {
@@ -68,7 +69,7 @@ void onReceive(int) {
           gotMask |= (1u << (f_off + i));
         }
         // all 12 received at least once?
-        if (gotMask == 0x0FFF) { newSensorData = true; gotMask = 0; }
+        if (gotMask == 0x0FFF) { haveData = true; gotMask = 0; }
 
         st = 0; // ready for next frame
       }
@@ -175,17 +176,12 @@ void setup() {
 
 void loop() {
   mqttClient.poll();
-  // mqttClient.beginMessage(topic);
-  // mqttClient.print(random(0, 100));
-  // mqttClient.endMessage();
-  // delay(1000);
-  if (newSensorData) {
+  if (haveData && millis() - lastPublish >= PUBLISH_INTERVAL_MS) {
+    lastPublish = millis();
     noInterrupts();
     uint16_t snap[SENSOR_COUNT];
     for (int i = 0; i < SENSOR_COUNT; i++) snap[i] = rcvDistances[i];
-    newSensorData = false;
     interrupts();
-
     mqttClient.beginMessage(topic);
     for (int i = 0; i < SENSOR_COUNT; i++) {
       if (i) mqttClient.print(',');
@@ -193,11 +189,5 @@ void loop() {
     }
     mqttClient.endMessage();
   }
-  delay(100);
-  mqttClient.poll(); 
-  mqttClient.beginMessage(random_topic); 
-  mqttClient.print(random(0, 100)); 
-  mqttClient.endMessage(); 
-  delay(1000);
 }
 


### PR DESCRIPTION
## Summary
- Streamline Mega sensor sketch by removing clock/rail display, adding interrupt-driven updates, and adding a 10s timeout for Uno R4 handshake.
- Publish sensor readings from Uno R4 at a fixed rate using a simple `millis()` scheduler instead of the incompatible Ticker library.
- Retain RTC support without displaying the current time.
- Define motor trigger constants before use to fix missing `TRIGGER_MM` declaration.

## Testing
- `arduino-cli --version` *(fails: command not found)*
- `python -m py_compile mqtt_listener.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc86249b4c83319709c76f96d5125d