### PR TITLE
Send sensor readings as JSON over MQTT

### DIFF
--- a/mqtt_listener.py
+++ b/mqtt_listener.py
@@ -5,6 +5,7 @@ Connects to a local broker and prints any messages published on the
 `unoR4/random` topic.
 """
 
+import json
 import paho.mqtt.client as mqtt
 
 BROKER = "10.60.245.204"  # replace with broker IP if not local
@@ -18,8 +19,9 @@ def on_connect(client, userdata, flags, rc):
 
 
 def on_message(client, userdata, msg):
-    """Print incoming MQTT messages."""
-    print(f"{msg.topic}: {msg.payload.decode()}")
+    """Print incoming MQTT messages as JSON."""
+    payload = json.loads(msg.payload.decode())
+    print(f"{msg.topic}: {payload}")
 
 
 client = mqtt.Client()

--- a/unoR4/unoR4.ino
+++ b/unoR4/unoR4.ino
@@ -187,10 +187,12 @@ void loop() {
     for (int i = 0; i < SENSOR_COUNT; i++) snap[i] = rcvDistances[i];
     interrupts();
     mqttClient.beginMessage(topic);
+    mqttClient.print("{\"distances\":[");
     for (int i = 0; i < SENSOR_COUNT; i++) {
       if (i) mqttClient.print(',');
       mqttClient.print(snap[i]);
     }
+    mqttClient.print("]}");
     mqttClient.endMessage();
   }
 


### PR DESCRIPTION
## Summary
- publish sensor readings as JSON instead of comma-separated values
- parse JSON payloads in MQTT listener

## Testing
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y arduino-cli` *(fails: package not located)*
- `python -m py_compile mqtt_listener.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef334ebf48331abaa0d97d2f45454