### PR TITLE
Add dedicated pulse timing for food stepper motor

### DIFF
--- a/allSensors/allSensors/allSensors.ino
+++ b/allSensors/allSensors/allSensors.ino
@@ -74,6 +74,7 @@ const int STEPS_90_FOOD = (STEPS_PER_REV_FOOD * MICROSTEPS) / 4;  // quarter tur
 
 // pulse timing (adjust for your driver/motor)
 const unsigned int STEP_PULSE_US = 600;   // high/low pulse width
+const unsigned int STEP_PULSE_FOOD_US = 1800; // high/low pulse width for food motor
 
 // --- state for motor trigger & switch edge ---
 unsigned long lastMoveMs = 0;
@@ -147,9 +148,9 @@ void motorStepFood(int steps, bool dirCW) {
   delayMicroseconds(2); // DIR setup time
   for (int i = 0; i < steps; i++) {
     digitalWrite(STEP_PIN2, HIGH);
-    delayMicroseconds(STEP_PULSE_US);
+    delayMicroseconds(STEP_PULSE_FOOD_US);
     digitalWrite(STEP_PIN2, LOW);
-    delayMicroseconds(STEP_PULSE_US);
+    delayMicroseconds(STEP_PULSE_FOOD_US);
   }
 }
 


### PR DESCRIPTION
## Summary
- Introduce `STEP_PULSE_FOOD_US` for the food dispenser stepper motor
- Use `STEP_PULSE_FOOD_US` in `motorStepFood` for stronger torque

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5ab48b23c8331abb3e942235ca9a9