### PR TITLE
Reduce stepper motor idle current and correct food motor steps

### DIFF
--- a/allSensors/allSensors/allSensors.ino
+++ b/allSensors/allSensors/allSensors.ino
@@ -66,9 +66,11 @@ void timerISR() { updateFlag = true; }
 // Second driver: STEP on pin 34, DIR on pin 36
 #define STEP_PIN2      34
 #define DIR_PIN2       36
+#define EN_PIN         35
+#define EN_PIN2        37
 #define MICROSTEPS      8     // set to the hardware microstep setting (1,2,4,8,16, ...)
 #define STEPS_PER_REV      200     // 1.8° motor
-#define STEPS_PER_REV_FOOD  64     // gear motor for food dispenser
+#define STEPS_PER_REV_FOOD  516     // gear motor for food dispenser
 const int STEPS_90      = (STEPS_PER_REV * MICROSTEPS) / 4;       // quarter turn main motor
 const int STEPS_90_FOOD = (STEPS_PER_REV_FOOD * MICROSTEPS) / 4;  // quarter turn food motor
 
@@ -133,6 +135,7 @@ void oledPrintf(uint8_t x, uint8_t y, const __FlashStringHelper* label, int valu
 }
 
 void motorStep(int steps, bool dirCW) {
+  digitalWrite(EN_PIN, LOW); // enable driver
   digitalWrite(DIR_PIN, dirCW ? HIGH : LOW);
   delayMicroseconds(2); // DIR setup time
   for (int i = 0; i < steps; i++) {
@@ -141,9 +144,11 @@ void motorStep(int steps, bool dirCW) {
     digitalWrite(STEP_PIN, LOW);
     delayMicroseconds(STEP_PULSE_US);
   }
+  digitalWrite(EN_PIN, HIGH); // disable driver to remove holding torque
 }
 
 void motorStepFood(int steps, bool dirCW) {
+  digitalWrite(EN_PIN2, LOW); // enable driver
   digitalWrite(DIR_PIN2, dirCW ? HIGH : LOW);
   delayMicroseconds(2); // DIR setup time
   for (int i = 0; i < steps; i++) {
@@ -152,6 +157,7 @@ void motorStepFood(int steps, bool dirCW) {
     digitalWrite(STEP_PIN2, LOW);
     delayMicroseconds(STEP_PULSE_FOOD_US);
   }
+  digitalWrite(EN_PIN2, HIGH); // disable driver to remove holding torque
 }
 
 bool initSensorOn(uint8_t ch, uint8_t idxInCh) {
@@ -412,6 +418,10 @@ void setup() {
   pinMode(STEP_PIN2, OUTPUT);
   pinMode(DIR_PIN2, OUTPUT);
   digitalWrite(STEP_PIN2, LOW);
+  pinMode(EN_PIN, OUTPUT);
+  digitalWrite(EN_PIN, HIGH); // disable driver at start
+  pinMode(EN_PIN2, OUTPUT);
+  digitalWrite(EN_PIN2, HIGH); // disable food driver at start
 
   for (uint8_t i = 0; i < 4; i++) {
     pinMode(hallPins[i], INPUT_PULLUP);

--- a/multiple_sensors_multiplex/multiple_sensors_multiplex.ino
+++ b/multiple_sensors_multiplex/multiple_sensors_multiplex.ino
@@ -26,12 +26,19 @@
 
 #define PRESENCE_PIN 40
 
-#define MOTOR_STEPS 200 //64 for Small stepper!
+#define MOTOR_STEPS 516 // steps per revolution for food motor
 #define MOTOR_PIN1 22
 #define MOTOR_PIN2 23
 #define MOTOR_PIN3 25
 #define MOTOR_PIN4 24
 Stepper stepper(MOTOR_STEPS, MOTOR_PIN1, MOTOR_PIN2, MOTOR_PIN3, MOTOR_PIN4);
+
+void disableStepper() {
+  digitalWrite(MOTOR_PIN1, LOW);
+  digitalWrite(MOTOR_PIN2, LOW);
+  digitalWrite(MOTOR_PIN3, LOW);
+  digitalWrite(MOTOR_PIN4, LOW);
+}
 
 
 #define LOG_INTERVAL 5000  
@@ -92,6 +99,7 @@ void setup() {
   // Serial.begin(9600);
   Wire.begin();
   stepper.setSpeed(50);
+  disableStepper();
 
  //  Initialize presence sensor Pin
   pinMode(PRESENCE_PIN, INPUT_PULLUP);
@@ -293,9 +301,9 @@ void loop() {
       }
     }
 
-    // Rotate stepper motor 90 degrees (50 steps)
-    // stepper.step(50); //good for nema17 motor
-    stepper.step(50);
+    // Rotate stepper motor 90 degrees (129 steps)
+    stepper.step(129);
+    disableStepper();
     // Resume sensors
     for (uint8_t ch = 0; ch < CHANNEL_COUNT; ch++) {
       tcaSelect(ch);
@@ -308,10 +316,7 @@ void loop() {
 
     } else {
       // digitalWrite(LED_BUILTIN, LOW);  // Turn off LED
-      digitalWrite(MOTOR_PIN1, LOW);
-      digitalWrite(MOTOR_PIN2, LOW);
-      digitalWrite(MOTOR_PIN3, LOW);
-      digitalWrite(MOTOR_PIN4, LOW);
+      disableStepper();
       
     }
 


### PR DESCRIPTION
## Summary
- set food stepper to 516 steps per revolution
- add enable pins so stepper drivers are disabled when idle
- ensure test sketch releases motor coils after each move

## Testing
- `arduino-cli compile allSensors/allSensors/allSensors.ino` *(command not found: arduino-cli)*
- `apt-get update` *(403 errors: repository not signed)*
- `arduino-cli compile multiple_sensors_multiplex/multiple_sensors_multiplex.ino` *(command not found: arduino-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ad8cf7c48331a95cdf2dddd43445