### PR TITLE
Fix side 4 menu selection and adjust confirm spacing

### DIFF
--- a/allSensors/allSensors/allSensors.ino
+++ b/allSensors/allSensors/allSensors.ino
@@ -598,7 +598,7 @@ void showMenuConfirm() {
   }
 
   display.setTextSize(1);
-  display.setCursor(0, 52);
+  display.setCursor(0, 44);
   display.println(F("1=Save 2=Again"));
   display.setCursor(0, 56);
   display.println(F("3=Menu 4=Opt"));
@@ -793,16 +793,11 @@ void handleButtonPress(uint8_t index, unsigned long now) {
 
   switch (currentMode) {
     case MODE_MENU_SELECT_SIDE:
-      if (number >= 1 && number <= 3) {
+      if (number >= 1 && number <= SIDE_COUNT) {
         menuSelectedSide = number;
         resetMenuSequenceBuffer();
         currentMode = MODE_MENU_ENTER_SEQUENCE;
         showMenuEnterSequence();
-      } else if (number == 4) {
-        menuSelectedSide = 0;
-        resetMenuSequenceBuffer();
-        currentMode = MODE_MENU_MORE_OPTIONS;
-        showMenuMoreOptions();
       }
       break;
     case MODE_MENU_ENTER_SEQUENCE:


### PR DESCRIPTION
## Summary
- allow selecting side 4 to enter the sequence entry screen instead of redirecting to the options menu
- reposition the confirmation screen action labels to provide spacing between the two rows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8f09f2fb48331bdc426ff1c0975a5