### PR TITLE
Add millis fallback for sensor timer

### DIFF
--- a/allSensors/allSensors/allSensors.ino
+++ b/allSensors/allSensors/allSensors.ino
@@ -3214,7 +3214,17 @@ void loop() {
     sensorUpdateFlag = false;
     timerTick = true;
   }
+  // Fallback: if the interrupt ever stops firing, use millis()
+  static unsigned long lastLoopSensorMs = 0;
+  uint16_t intervalCopy = sensorUpdateIntervalTicks;
   interrupts();
+
+  if (timerTick) {
+    lastLoopSensorMs = now;
+  } else if (now - lastLoopSensorMs >= intervalCopy) {
+    timerTick = true;
+    lastLoopSensorMs = now;
+  }
 
   // ---------------------------------------------------------
   // 3. PROCESS PENDING BUTTON SCANS


### PR DESCRIPTION
## Summary
- add a loop-based fallback so sensor updates continue even if the timer interrupt stops firing

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fcb144288331850512f28018ae2e)